### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/google/latlong2zip.py
+++ b/google/latlong2zip.py
@@ -63,7 +63,7 @@ def main(options, args):
         # Check input file contains minimum columns
         for c in ['uniqid', 'lat', 'long']:
             if c not in fields:
-                print("ERROR: Input file don't have column '%s'" % c)
+                print("ERROR: Input file don't have column '{0!s}'".format(c))
                 return
         if 'zipcode' not in fields:
             fields.append('zipcode')
@@ -85,7 +85,7 @@ def main(options, args):
             lat = float(r['lat']) 
             lon = float(r['long'])
             try:
-                print("Query zipcode for lat = %f, long = %f" % (lat, lon))
+                print("Query zipcode for lat = {0:f}, long = {1:f}".format(lat, lon))
                 zipcode = LatLonToZip(lat, lon)
                 if zipcode == None:
                     zipcode = 'N/A'
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     sys.setdefaultencoding('utf-8')
     sys.stdout = Logger(LOGFILE)
     signal.signal(signal.SIGINT, signal_handler)
-    print("%s r1 (2013/08/28)\n" % (os.path.basename(sys.argv[0])))
+    print("{0!s} r1 (2013/08/28)\n".format((os.path.basename(sys.argv[0]))))
     (options, args) = parse_command_line(sys.argv)
     if len(args) < 2:
         print("Please specific input file (CSV)")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:soodoku:latlong-to-zip?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:soodoku:latlong-to-zip?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
